### PR TITLE
Add permissions to build to maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,6 +16,11 @@ on:
 
 jobs:
   build:
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+      pull-requests: write
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Needed for dependabot alerts CI/CD related tasks, else it fails with:

```
HTTP Status 403 for request POST https://api.github.com/repos/rmachuca89/java-lab/dependency-graph/snapshots
```

Source: https://sjramblings.io/github-actions-resource-not-accessible-by-integration